### PR TITLE
Debug mode shouldn't change the data strucure

### DIFF
--- a/ggautoblocker.pl
+++ b/ggautoblocker.pl
@@ -201,9 +201,7 @@ if ( $debug ) {
 	print "Saving list of IDs to block_ids.txt.\n";
 	open BL, '>block_ids.txt' or die "Can't open block_ids.txt: $!\n";
 	foreach my $monster ( keys %problem ) {
-		if ( $problem{$monster}->{'count'} == 1 ) {
-			delete $problem{$monster};
-		} else {
+		if ( exists $problem{$monster}->{'count'} ) {
 			print BL "$monster\n";
 		}
 	}


### PR DESCRIPTION
It looks like you've got some code here that (in debug mode) deletes all of the problem children with only one count. It's hard to me to figure out what the intention is here, but I assume that your data structures are supposed to behave the same in debug mode as in release mode, yes? Also, your script doesn't work in debug mode if there's only 1 entry in the sourcelist. (expected behavior, maybe? unclear from the comments)
