### PR TITLE
Add Nero's alias Caligula

### DIFF
--- a/sourcelist.txt
+++ b/sourcelist.txt
@@ -1,4 +1,5 @@
 Nero
+Caligula
 FartToContinue
 PlayDangerously
 roguestargamez


### PR DESCRIPTION
OK, maybe I'm completely wrong here, but I assume there's no particular reason why his alt isn't also on the source list? Is it not used to coordinate raids or something?